### PR TITLE
Support usage as passive middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ app.get('/somepage', myPageTest.getVariant, function (req, res) {
 });
 ```
 
+### Usage as passive middleware
+
+If you need the variant information in many routes in your application, and need cookies to be assigned for any/all of them, you can create your variants as general purpose middleware instead of attaching it to specific routes.
+
+```javascript
+var variants = ['A', 'B', 'C'];
+for (var i = 0; i < variants.length; i++) {
+    app.use(myPageTest(variants[i]));
+}
+
+app.get('/somepage', myPageTest.getVariant, function(req, res) {
+    res.send('variant ' + res.locals.ab.variantId);
+});
+```
+
 ### Disable cookie
 
 If you do not want the user to be sent to the same variant in the test on every return, you can disable cookies like this:

--- a/lib/express-ab.js
+++ b/lib/express-ab.js
@@ -53,6 +53,10 @@ ab.test = function (testName, opts) {
                 done = respond.bind(null, res, next, variant, cookie),
                 skip, keys;
 
+            if (res.locals.ab) {
+              return done('route');
+            }
+
             if (cookie && cookie.hasOwnProperty(testName)) {
                 return cookie[testName] === variant ? done() : done('route');
             }

--- a/test/passive.js
+++ b/test/passive.js
@@ -1,0 +1,43 @@
+var ab = require('../lib/express-ab');
+var assert = require('assert');
+var cookieParser = require('cookie-parser');
+var express = require('express');
+var helpers = require('./helpers');
+var request = require('supertest');
+
+describe('passive middleware', function() {
+    var app = express();
+    app.use(cookieParser());
+
+    var abTest = ab.test('unit-test');
+
+    var variants = ['variantA', 'variantB', 'variantC'];
+    for (var i = 0; i < variants.length; i++) {
+        app.use(abTest(variants[i]));
+    }
+
+    app.get('/', abTest.getVariant, function(req, res) {
+        res.send(res.locals.ab.variantId);
+    });
+
+    it('should assign a cookie and populate res.locals.ab', function(done) {
+        request(app)
+            .get('/')
+            .expect('variantA')
+            .expect('set-cookie', /^ab=%7B%22unit-test%22%3A%22variantA%22%7D;/, done);
+    });
+
+    it('should still round robin properly', function(done) {
+        request(app)
+            .get('/')
+            .expect('variantB')
+            .expect('set-cookie', /^ab=%7B%22unit-test%22%3A%22variantB%22%7D;/, done);
+    });
+
+    it('should still honor cookies', function(done) {
+        request(app)
+            .get('/')
+            .set('Cookie', ['ab=%7B%22unit-test%22%3A%22variantA%22%7D'])
+            .expect('variantA', done);
+    });
+});


### PR DESCRIPTION
The ab tests I'm doing will require changes to several routes and I can't rely on advanced knowledge of which the user will hit first. As a result, `getVariant()` is close to what I need, but it doesn't quite cut it. I need the user to actually be _assigned_ a variant regardless of which route they enter on and then I need to be able to read it on any/all routes in the application.

To support this, I'd love to be able to use the package as passive middleware as shown in the readme documentation in the pull request. It only requires a slight non-breaking change in the middleware that ensures it does not overwrite `res.locals.ab` when it has already written to it.

I've added documentation and tests as well.