### PR TITLE
When variants' weight set to 0/100, traffic will be send to 0% variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
   - 4
   - 5
+  - 8
+  - 9
+  - 10
 script: "npm run-script test-travis"
 after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"

--- a/lib/express-ab.js
+++ b/lib/express-ab.js
@@ -12,6 +12,10 @@ function ab(opts) {
     return ab;
 }
 
+function isWeightDefined(weight) {
+    return (typeof weight === 'number' && weight >= 0 && weight <= 1);
+}
+
 ab.test = function (testName, opts) {
     if (!testName) throw '.test() requires first parameter "name" (type string)';
 
@@ -63,14 +67,14 @@ ab.test = function (testName, opts) {
                 return cookie[testName] === variant ? done() : done('route');
             }
 
-            if (weight && !req.ab) {
+            if (isWeightDefined(weight) && !req.ab) {
                 req.ab = {
                     random: Math.random(),
                     weightSum: 0
                 };
             }
 
-            if (weight) {
+            if (isWeightDefined(weight)) {
                 req.ab.weightSum += weight;
                 skip = req.ab.random > req.ab.weightSum;
             } else if (req.ab) {

--- a/test/weighted.js
+++ b/test/weighted.js
@@ -61,4 +61,27 @@ describe('weighted', function () {
                 .expect('variantC', done);
         });
     });
+
+    describe('0%/100% variants', function() {
+        before(function () {
+            app = express();
+            abTest = ab.test('fallthrough-test');
+            app.get('/', helpers.setReqVar, abTest('a', 0), helpers.send('variantA'));
+            app.get('/', helpers.setReqVar, abTest('b', 1), helpers.send('variantB'));
+        });
+
+        it('should always go to variant B when A set to 0', function(done) {
+            request(app)
+                .get('/')
+                .set('ab-random', 0.11)
+                .expect('variantB', done);
+        });
+
+        it('should always go to variant B when A set to 0', function (done) {
+            request(app)
+                .get('/')
+                .set('ab-random', 1)
+                .expect('variantB', done);
+        });
+    });
 });


### PR DESCRIPTION
**Issue description**
If I have 2 variants, the weight of variant A is set to `0`, variant B is set to `1`, the previous code will treat the weight of variant A not set, and send request to variant A.

Weight = `0` could happen when we have this variant, but we don't want end users see it before we test it ourselves.

```javascript
if (weight) { // weight = 0 can't pass this validation
    req.ab.weightSum += weight;
    skip = req.ab.random > req.ab.weightSum;
} else if (req.ab) {
    skip = false;
} else {
    keys = Object.keys(test);
    skip = keys.some(function (key) {
        return test[key] < current;
    });
}
```

So I changed the `if (weight)` to validate is `weight` is a number between `[0, 1]`, also added tests for this situation.

Could you help review the code? And let me know if I misunderstood anything or it doesn't make sense to you. Thanks in advance!

Regards,
Yue